### PR TITLE
Add TypeScript glTF-Transform example for B4Z extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # glTF
-Personal extensions for glTF
+Personal extensions for glTF.
+
+## Extensions
+
+- [B4Z_node_additional_meshes](extensions/2.0/B4Z_node_additional_meshes/README.md) — attaches additional topology representations (point clouds, edge meshes, volumetric cells, etc.) to existing scene nodes.
+
+## Examples
+
+- [TypeScript glTF-Transform sample](examples/typescript/README.md) — shows how to author `B4Z_node_additional_meshes` payloads programmatically.

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -1,0 +1,27 @@
+# TypeScript example: B4Z_node_additional_meshes
+
+This example shows how to implement support for the `B4Z_node_additional_meshes` extension with [glTF-Transform](https://gltf-transform.donmccurdy.com/). The accompanying TypeScript source demonstrates how to:
+
+- Declare a custom `Extension` and `ExtensionProperty` pair that mirror the extension schema.
+- Populate a document with additional mesh data (vertices, indices, and auxiliary attributes) shared across multiple topologies.
+- Register the extension with `NodeIO` to serialize the authoring result as a `.gltf` asset.
+
+> **Note**
+> The code focuses on the authoring workflow; production-ready tooling should add further validation and cover the JSON reader path.
+
+## Running the example
+
+1. Install dependencies (glTF-Transform v3.7 or newer is recommended):
+   ```bash
+   npm install @gltf-transform/core @gltf-transform/extensions
+   ```
+2. Compile the TypeScript source:
+   ```bash
+   npx tsc b4z-node-additional-meshes-extension.ts --target ES2020 --moduleResolution node --module commonjs
+   ```
+3. Execute the generated JavaScript file to emit `mixed-topologies.gltf`:
+   ```bash
+   node b4z-node-additional-meshes-extension.js
+   ```
+
+Inspect the resulting asset to see the serialized `B4Z_node_additional_meshes` payload on the root node.

--- a/examples/typescript/b4z-node-additional-meshes-extension.ts
+++ b/examples/typescript/b4z-node-additional-meshes-extension.ts
@@ -1,0 +1,270 @@
+import {
+  Accessor,
+  Document,
+  Extension,
+  ExtensionProperty,
+  Graph,
+  IProperty,
+  NodeIO,
+  PropertyType,
+  WriterContext,
+} from '@gltf-transform/core';
+
+const EXTENSION_NAME = 'B4Z_node_additional_meshes';
+
+type AdditionalMeshTopology =
+  | 'POINTS'
+  | 'LINES'
+  | 'LINE_STRIP'
+  | 'TRIANGLES'
+  | 'TRIANGLE_STRIP'
+  | 'TRIANGLE_FAN'
+  | 'QUADS'
+  | 'QUAD_STRIP'
+  | 'POLYGONS'
+  | 'TETRAHEDRA'
+  | 'PYRAMIDS'
+  | 'WEDGES'
+  | 'PENTA_PRISMS'
+  | 'HEXAHEDRA';
+
+interface IAdditionalMesh extends IProperty {
+  id: string;
+  topology: AdditionalMeshTopology;
+  vertices: Accessor | null;
+  indices: Accessor | null;
+  attributes: Map<string, Accessor>;
+}
+
+class AdditionalMesh extends ExtensionProperty<IAdditionalMesh> {
+  public static EXTENSION_NAME = EXTENSION_NAME;
+  public declare extensionName: typeof EXTENSION_NAME;
+  public declare propertyType: 'AdditionalMesh';
+  public declare parentTypes: [PropertyType.NODE];
+
+  private _id = '';
+  private _topology: AdditionalMeshTopology = 'POINTS';
+  private _vertices: Accessor | null = null;
+  private _indices: Accessor | null = null;
+  private _attributes: Map<string, Accessor> = new Map();
+
+  constructor(graph: Graph) {
+    super(graph);
+    this.extensionName = EXTENSION_NAME;
+    this.propertyType = 'AdditionalMesh';
+    this.parentTypes = [PropertyType.NODE];
+  }
+
+  public setId(id: string): this {
+    this._id = id;
+    return this;
+  }
+
+  public getId(): string {
+    return this._id;
+  }
+
+  public setTopology(topology: AdditionalMeshTopology): this {
+    this._topology = topology;
+    return this;
+  }
+
+  public getTopology(): AdditionalMeshTopology {
+    return this._topology;
+  }
+
+  public setVertices(accessor: Accessor): this {
+    this._vertices = accessor;
+    this.attachElement('vertices', accessor);
+    return this;
+  }
+
+  public getVertices(): Accessor | null {
+    return this._vertices;
+  }
+
+  public setIndices(accessor: Accessor): this {
+    this._indices = accessor;
+    this.attachElement('indices', accessor);
+    return this;
+  }
+
+  public getIndices(): Accessor | null {
+    return this._indices;
+  }
+
+  public setAttribute(semantic: string, accessor: Accessor): this {
+    this._attributes.set(semantic, accessor);
+    this.attachElement(`attributes/${semantic}`, accessor);
+    return this;
+  }
+
+  public listAttributes(): Array<[string, Accessor]> {
+    return Array.from(this._attributes.entries());
+  }
+
+  public toJSON(context: WriterContext) {
+    if (!this._vertices || !this._indices) {
+      throw new Error('Additional meshes require both vertices and indices accessors.');
+    }
+
+    const attributes: Record<string, number> = {};
+    for (const [semantic, accessor] of this._attributes) {
+      attributes[semantic] = context.accessorIndexMap.get(accessor)!;
+    }
+
+    return {
+      id: this._id,
+      topology: this._topology,
+      vertices: context.accessorIndexMap.get(this._vertices)!,
+      indices: context.accessorIndexMap.get(this._indices)!,
+      attributes: Object.keys(attributes).length ? attributes : undefined,
+    };
+  }
+}
+
+class AdditionalMeshSet extends ExtensionProperty<IProperty> {
+  public static EXTENSION_NAME = EXTENSION_NAME;
+  public declare extensionName: typeof EXTENSION_NAME;
+  public declare propertyType: 'AdditionalMeshSet';
+  public declare parentTypes: [PropertyType.NODE];
+
+  private meshes: AdditionalMesh[] = [];
+
+  constructor(graph: Graph) {
+    super(graph);
+    this.extensionName = EXTENSION_NAME;
+    this.propertyType = 'AdditionalMeshSet';
+    this.parentTypes = [PropertyType.NODE];
+  }
+
+  public addMesh(mesh: AdditionalMesh): this {
+    this.meshes.push(mesh);
+    mesh.setParent(this, 'meshes', this.meshes.length - 1);
+    return this;
+  }
+
+  public listMeshes(): AdditionalMesh[] {
+    return this.meshes;
+  }
+}
+
+export class B4ZNodeAdditionalMeshesExtension extends Extension {
+  public readonly extensionName = EXTENSION_NAME;
+  public static readonly EXTENSION_NAME = EXTENSION_NAME;
+
+  public createAdditionalMesh(): AdditionalMesh {
+    return new AdditionalMesh(this.document.getGraph());
+  }
+
+  public createAdditionalMeshSet(): AdditionalMeshSet {
+    return new AdditionalMeshSet(this.document.getGraph());
+  }
+
+  public write(context: WriterContext): this {
+    const root = this.document.getRoot();
+    const jsonDoc = context.jsonDoc;
+
+    const used = new Set<string>(jsonDoc.json.extensionsUsed ?? []);
+    used.add(EXTENSION_NAME);
+    jsonDoc.json.extensionsUsed = Array.from(used);
+
+    for (const node of root.listNodes()) {
+      const meshSet = node.getExtension<AdditionalMeshSet>(EXTENSION_NAME);
+      if (!meshSet) continue;
+
+      const nodeIndex = context.nodeIndexMap.get(node);
+      if (nodeIndex === undefined) continue;
+
+      const nodeDef = jsonDoc.json.nodes![nodeIndex];
+      nodeDef.extensions = nodeDef.extensions || {};
+      nodeDef.extensions[EXTENSION_NAME] = {
+        meshes: meshSet.listMeshes().map((mesh) => mesh.toJSON(context)),
+      };
+    }
+
+    return this;
+  }
+}
+
+async function main() {
+  const document = new Document();
+  const root = document.getRoot();
+
+  const extension = document.createExtension(B4ZNodeAdditionalMeshesExtension);
+
+  // Create shared vertex accessor.
+  const vertexAccessor = document
+    .createAccessor('shared-positions')
+    .setType(Accessor.Type.VEC3)
+    .setArray(new Float32Array([
+      0, 0, 0,
+      1, 0, 0,
+      0, 1, 0,
+      0, 0, 1,
+      1, 1, 0,
+      0, 1, 1,
+      1, 0, 1,
+      1, 1, 1,
+    ]));
+
+  // Topology-specific index accessors.
+  const tetraAccessor = document
+    .createAccessor('tetra-cells')
+    .setType(Accessor.Type.SCALAR)
+    .setArray(new Uint16Array([
+      0, 1, 2, 3,
+    ]));
+
+  const hexaAccessor = document
+    .createAccessor('hex-cells')
+    .setType(Accessor.Type.SCALAR)
+    .setArray(new Uint16Array([
+      0, 1, 4, 2, 3, 6, 7, 5,
+    ]));
+
+  const tetraCellIds = document
+    .createAccessor('tetra-cell-ids')
+    .setType(Accessor.Type.SCALAR)
+    .setArray(new Uint32Array([100]));
+
+  const hexCellIds = document
+    .createAccessor('hex-cell-ids')
+    .setType(Accessor.Type.SCALAR)
+    .setArray(new Uint32Array([200]));
+
+  const node = document.createNode('MixedTopology');
+  root.addNode(node);
+
+  const meshSet = extension.createAdditionalMeshSet();
+
+  meshSet.addMesh(
+    extension
+      .createAdditionalMesh()
+      .setId('tetra_cluster')
+      .setTopology('TETRAHEDRA')
+      .setVertices(vertexAccessor)
+      .setIndices(tetraAccessor)
+      .setAttribute('CELL_IDS', tetraCellIds),
+  );
+
+  meshSet.addMesh(
+    extension
+      .createAdditionalMesh()
+      .setId('hex_core')
+      .setTopology('HEXAHEDRA')
+      .setVertices(vertexAccessor)
+      .setIndices(hexaAccessor)
+      .setAttribute('CELL_IDS', hexCellIds),
+  );
+
+  node.setExtension(EXTENSION_NAME, meshSet);
+
+  const io = new NodeIO().registerExtensions([B4ZNodeAdditionalMeshesExtension]);
+  await io.writeJSON('mixed-topologies.gltf', document);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/extensions/2.0/B4Z_node_additional_meshes/README.md
+++ b/extensions/2.0/B4Z_node_additional_meshes/README.md
@@ -1,0 +1,164 @@
+# B4Z_node_additional_meshes
+
+## Contributors
+- B4Z
+
+## Status
+Draft
+
+## Dependencies
+Written against the glTF 2.0 specification.
+
+## Overview
+`B4Z_node_additional_meshes` allows a glTF node to reference an arbitrary number of auxiliary meshes that supplement the primary `mesh` property. The extension is intended for workflows that need to attach alternate topological representations of the same spatial object — for example point clouds, edge complexes, tetrahedral meshes, hexahedral meshes, or any other scientific or simulation meshes — without duplicating the node hierarchy.
+
+Each additional mesh carries:
+
+- A user defined identifier.
+- An enumeration describing the topological type of the primitive set.
+- A reference to the vertex positions.
+- A reference to primitive indices that describe connectivity appropriate for the topology.
+
+The data for the vertices and indices are stored in accessors exactly like any other glTF attribute or index data. This allows applications to reuse buffers, buffer views, and accessors, and it keeps binary assets GPU friendly.
+
+## glTF Schema Updates
+
+### Node
+
+The `extensions` property of a node MAY contain a `B4Z_node_additional_meshes` object with the following schema:
+
+```json
+"nodes": [
+  {
+    "extensions": {
+      "B4Z_node_additional_meshes": {
+        "meshes": [
+          {
+            "id": "tetra_01",
+            "topology": "TETRAHEDRA",
+            "vertices": 3,
+            "indices": 8
+          }
+        ]
+      }
+    }
+  }
+]
+```
+
+| Property   | Type     | Required | Description |
+|------------|----------|----------|-------------|
+| `meshes`   | array    | Yes      | Array of additional mesh definitions scoped to the node. |
+
+Each element of `meshes` is defined as follows:
+
+| Property   | Type     | Required | Description |
+|------------|----------|----------|-------------|
+| `id`       | string   | Yes      | Author-defined identifier that is unique within the node. Useful when multiple application subsystems refer to the same additional mesh. |
+| `topology` | string   | Yes      | Enumerated identifier describing the primitive topology. Valid values: `POINTS`, `LINES`, `LINE_STRIP`, `TRIANGLES`, `TRIANGLE_STRIP`, `TRIANGLE_FAN`, `QUADS`, `QUAD_STRIP`, `POLYGONS`, `TETRAHEDRA`, `PYRAMIDS`, `WEDGES`, `PENTA_PRISMS`, `HEXAHEDRA`. |
+| `vertices` | integer  | Yes      | Index of an accessor containing vertex positions for the mesh. The accessor element type MUST be `VEC3` with `FLOAT` component type and MUST be expressed in the node's coordinate space, matching the rules for the core `POSITION` attribute. |
+| `indices`  | integer  | Yes      | Index of an accessor that describes the primitive connectivity for the specified topology. The accessor component type MUST be one of `UNSIGNED_BYTE`, `UNSIGNED_SHORT`, or `UNSIGNED_INT`. |
+| `attributes` | object | No       | Dictionary of additional vertex attributes. Keys follow the same conventions as `mesh.primitive.attributes`. Each value MUST be the index of an accessor whose count matches the `vertices` accessor. |
+| `metadata` | object   | No       | Application specific metadata. Treated as `extras` by the core spec. |
+
+The `indices` accessor describes how vertices are grouped into primitives. Applications interpret the accessor according to `topology`:
+
+- `POINTS`: each index represents a single vertex.
+- `LINES`: consecutive pairs of indices form line segments.
+- `LINE_STRIP`: indices are connected sequentially.
+- `TRIANGLES`, `TRIANGLE_STRIP`, `TRIANGLE_FAN`: follow the existing glTF semantics.
+- `QUADS`: consecutive groups of four indices form individual quads.
+- `QUAD_STRIP`: even/odd pairs form adjacent quads. The accessor count MUST be a multiple of two.
+- `POLYGONS`: the accessor MUST be accompanied by an `attributes.POLYGON_SIZES` accessor containing the vertex counts for each polygonal face.
+- `TETRAHEDRA`, `PYRAMIDS`, `WEDGES`, `PENTA_PRISMS`, `HEXAHEDRA`: indices are grouped according to the number of vertices for each cell (4, 5, 6, 5, and 8 respectively). Applications MAY extend the list for additional domain specific cell types.
+
+If `topology` requires auxiliary data (for example polygon sizes or per-cell attributes) the extension relies on the `attributes` dictionary to expose the additional accessors. Consumers that do not understand the auxiliary attributes may safely ignore them.
+
+### Additional Accessor Semantics
+
+To support higher dimensional cells the extension reserves the following attribute semantics:
+
+| Semantic            | Description |
+|---------------------|-------------|
+| `POLYGON_SIZES`     | `SCALAR` accessor whose components define the number of vertices for each polygon in a `POLYGONS` topology. The sum of its elements MUST equal the index accessor count. |
+| `CELL_IDS`          | `SCALAR` unsigned integer accessor that labels each topological cell. Useful for mapping simulation results. |
+| `CELL_GROUPS`       | `SCALAR` unsigned integer accessor that groups primitives for visualization (for example material regions or boundary conditions). |
+
+Additional custom semantics MAY be introduced by prefixing them with an application specific namespace (for example, `SIM_pressure`).
+
+## Interactions with glTF Features
+
+- Nodes that use `B4Z_node_additional_meshes` MAY still specify the core `mesh` property. Rendering engines that do not understand the extension ignore it and fall back to the standard mesh.
+- Accessors referenced by the extension participate in the same resource reuse rules as standard accessors: they MAY be shared across multiple additional meshes or core primitives.
+- Morph targets and skinning are not defined for additional meshes in this version of the extension. Future revisions MAY add support if use-cases demand it.
+- The extension is purely descriptive; no additional animations or materials are defined. Applications MAY use the identifiers to cross-reference simulation data or additional metadata stored elsewhere.
+
+## Example Implementation
+
+A glTF-Transform authoring example that registers a custom extension and exports a mixed-topology asset is available under [`examples/typescript`](../../../examples/typescript/README.md).
+
+## JSON Schema
+
+A JSON schema describing the extension is provided below as guidance for validation. Integrators MAY translate it into their preferred tooling.
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "B4Z_node_additional_meshes",
+  "type": "object",
+  "properties": {
+    "meshes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "topology", "vertices", "indices"],
+        "properties": {
+          "id": { "type": "string" },
+          "topology": {
+            "type": "string",
+            "enum": [
+              "POINTS", "LINES", "LINE_STRIP", "TRIANGLES", "TRIANGLE_STRIP", "TRIANGLE_FAN",
+              "QUADS", "QUAD_STRIP", "POLYGONS", "TETRAHEDRA", "PYRAMIDS", "WEDGES", "PENTA_PRISMS", "HEXAHEDRA"
+            ]
+          },
+          "vertices": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "indices": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "attributes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "metadata": {
+            "type": "object"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["meshes"],
+  "additionalProperties": false
+}
+```
+
+## Conformance
+
+An implementation claiming support for `B4Z_node_additional_meshes` MUST adhere to the following:
+
+1. Validate that the accessor referenced by `vertices` is a `VEC3` with floating point components and that its count matches all attribute accessors.
+2. Validate that the accessor referenced by `indices` uses an unsigned integer component type and that its element count is compatible with the selected `topology`.
+3. Ignore any additional mesh whose `topology` value is not recognized.
+4. Advertise support by adding `"B4Z_node_additional_meshes"` to `extensionsUsed`. Add it to `extensionsRequired` if the asset cannot be meaningfully interpreted without the additional meshes.
+
+## Notes
+
+This draft intentionally restricts the scope to vertex positions and connectivity so that the extension can be implemented incrementally. Future revisions MAY add support for materials, morph targets, or skinning references once representative use-cases are identified.


### PR DESCRIPTION
## Summary
- add a TypeScript glTF-Transform example that serializes B4Z_node_additional_meshes
- document the new example in the extension README and project README

## Testing
- not run (example and documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d7dbb728e0832385941c8c211d6679